### PR TITLE
feat: #19 - [GET] 카페 검색 (지역, 키워드 검색 동적 쿼리) 개발 (/cafe/search)

### DIFF
--- a/src/main/java/com/maemae/escaperoom/EscapeRoomApplication.java
+++ b/src/main/java/com/maemae/escaperoom/EscapeRoomApplication.java
@@ -1,11 +1,13 @@
 package com.maemae.escaperoom;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import javax.persistence.EntityManager;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,5 +22,10 @@ public class EscapeRoomApplication {
     @Bean
     public AuditorAware<String> auditorProvider() {
         return () -> Optional.of(UUID.randomUUID().toString());
+    }
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
     }
 }

--- a/src/main/java/com/maemae/escaperoom/controller/CafeController.java
+++ b/src/main/java/com/maemae/escaperoom/controller/CafeController.java
@@ -2,13 +2,18 @@ package com.maemae.escaperoom.controller;
 
 import com.maemae.escaperoom.dto.CafeDTO;
 import com.maemae.escaperoom.service.CafeService;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,7 +22,22 @@ public class CafeController {
     private final CafeService cafeService;
 
     @GetMapping("/cafe/all")
-    public Page<CafeDTO> cafeAllList(@PageableDefault(size = 12, sort = "name") Pageable pageable) {
-        return cafeService.cafeAllList(pageable);
+    public Result cafeAllList(@PageableDefault(size = 12, sort = "location") Pageable pageable) {
+        Page<CafeDTO> cafeAllList = cafeService.cafeAllList(pageable);
+        return new Result(cafeAllList);
+    }
+
+    @GetMapping("/cafe/search")
+    public Result cafeSearchList(@RequestParam(required = false) List<String> loc,
+                                 @RequestParam(required = false) String keyword,
+                                 Pageable pageable) {
+        Page<CafeDTO> cafeSearchList = cafeService.cafeSearchList(loc, keyword, pageable);
+        return new Result(cafeSearchList);
+    }
+
+    @Data
+    @AllArgsConstructor
+    static class Result<T> {
+        private T data;
     }
 }

--- a/src/main/java/com/maemae/escaperoom/dto/CafeDTO.java
+++ b/src/main/java/com/maemae/escaperoom/dto/CafeDTO.java
@@ -1,6 +1,7 @@
 package com.maemae.escaperoom.dto;
 
 import com.maemae.escaperoom.entity.Cafe;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 
 @Data
@@ -22,5 +23,16 @@ public class CafeDTO {
         this.address = cafe.getAddress();
         this.domain = cafe.getDomain();
         this.location = cafe.getLocation();
+    }
+
+    @QueryProjection
+    public CafeDTO(Long cafeId, String name, String phoneNumber, String bhours, String address, String domain, String location) {
+        this.cafeId = cafeId;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.bhours = bhours;
+        this.address = address;
+        this.domain = domain;
+        this.location = location;
     }
 }

--- a/src/main/java/com/maemae/escaperoom/repository/CafeRepository.java
+++ b/src/main/java/com/maemae/escaperoom/repository/CafeRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CafeRepository extends JpaRepository<Cafe, Long> {
+public interface CafeRepository extends JpaRepository<Cafe, Long>, MemberRepositoryCustom {
 
     Page<Cafe> findAll(Pageable pageable);
 }

--- a/src/main/java/com/maemae/escaperoom/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/maemae/escaperoom/repository/MemberRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.maemae.escaperoom.repository;
+
+import com.maemae.escaperoom.dto.CafeDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface MemberRepositoryCustom {
+
+    Page<CafeDTO> cafeSearchPage(List<String> loc, String keyword, Pageable pageable);
+}

--- a/src/main/java/com/maemae/escaperoom/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/maemae/escaperoom/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,51 @@
+package com.maemae.escaperoom.repository;
+
+import com.maemae.escaperoom.dto.CafeDTO;
+import com.maemae.escaperoom.dto.QCafeDTO;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.maemae.escaperoom.entity.QCafe.cafe;
+import static org.springframework.util.StringUtils.hasText;
+
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MemberRepositoryCustomImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<CafeDTO> cafeSearchPage(List<String> loc, String keyword, Pageable pageable) {
+
+        QueryResults<CafeDTO> searchResults = queryFactory
+                .select(new QCafeDTO(cafe.id, cafe.name, cafe.phoneNumber,
+                        cafe.bhours, cafe.address, cafe.domain, cafe.location))
+                .from(cafe)
+                .where(locIn(loc), keywordContaining(keyword))
+                .orderBy(cafe.location.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchResults();
+
+        List<CafeDTO> contents = searchResults.getResults();
+        long total = searchResults.getTotal();
+
+        return new PageImpl<>(contents, pageable, total);
+    }
+
+    private BooleanExpression locIn(List<String> loc) {
+        return loc == null ? null : ( !loc.isEmpty() ? cafe.location.in(loc) : null );
+    }
+
+    private BooleanExpression keywordContaining(String keyword) {
+        return hasText(keyword) ? cafe.name.contains(keyword) : null;
+    }
+}

--- a/src/main/java/com/maemae/escaperoom/service/CafeService.java
+++ b/src/main/java/com/maemae/escaperoom/service/CafeService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class CafeService {
@@ -15,5 +17,9 @@ public class CafeService {
 
     public Page<CafeDTO> cafeAllList(Pageable pageable) {
         return cafeRepository.findAll(pageable).map(CafeDTO::new);
+    }
+
+    public Page<CafeDTO> cafeSearchList(List<String> loc, String keyword, Pageable pageable) {
+        return cafeRepository.cafeSearchPage(loc, keyword, pageable);
     }
 }


### PR DESCRIPTION
API 요청 예시 및 설명
https://{{host}}/cafe/search?loc=홍대&keyword=비밀
 : 지역이 홍대이면서 방탈출 카페 이름에 비밀이 포함되는 카페 list 반환 
https://{{host}}/cafe/search?loc=홍대&loc=건대&keyword=비밀  
 : 지역이 홍대 또는 건대이면서 카페 이름에 비밀이 포함되는 list 반환
https://{{host}}/cafe/search
 : 검색 조건이 없으므로 전체 list 반환

[feat:](https://github.com/maemae22/escape-room/commit/417bd9989e477cde6d2841e45f1d62725aedd8d5) https://github.com/maemae22/escape-room/issues/19 [- JPAQueryFactory를 Spring Bean으로 등록](https://github.com/maemae22/escape-room/commit/417bd9989e477cde6d2841e45f1d62725aedd8d5)

[feat:](https://github.com/maemae22/escape-room/commit/11b87b0db90a597b6babae390fe1783de387e65e) https://github.com/maemae22/escape-room/issues/19 [- CafeDTO에 @QueryProjection 추가](https://github.com/maemae22/escape-room/commit/11b87b0db90a597b6babae390fe1783de387e65e) 

- DTO로 조회하기 위하여 @QueryProjection 추가 (프로젝션과 결과 반환)
- 컴파일러로 타입 체크 가능 (컴파일 에러 캐치 가능)
- @QueryProjection 단점 : DTO에 QueryDSL 어노테이션을 유지해야함, DTO까지 Q 파일을 생성해야함


[feat:](https://github.com/maemae22/escape-room/commit/dbc6471fd7634f671b41e29c1d56adc20a384915) https://github.com/maemae22/escape-room/issues/19 [- Where 다중 파라미터 사용으로 카페 검색 동적 쿼리 작성 (Repository)](https://github.com/maemae22/escape-room/commit/dbc6471fd7634f671b41e29c1d56adc20a384915) 

- 파라미터로 받은 keyword가 빈 문자열(혹은 null)이 아닐 경우, name like '%keyword%' 으로 where 검색 조건 추가됨
- 파라미터로 받은 loc(List<String>)이 null이거나 isEmpty()가 아닐 경우, location in ('loc1', 'loc2')으로 where 검색 조건 추가됨
- location으로 ASC 정렬하여 반환함


[feat:](https://github.com/maemae22/escape-room/commit/55ca8326905ef2e8fecd28fceaa27a31bc9f49e6) https://github.com/maemae22/escape-room/issues/19 [- 카페 검색 (지역, 키워드 검색 동적 쿼리) API 작성 (Service, Controller)](https://github.com/maemae22/escape-room/commit/55ca8326905ef2e8fecd28fceaa27a31bc9f49e6) 

- /cafe/search API 작성
- List<String> loc와 String keyword를 @RequestParam을 통해 파라미터로 받을 수 있음
- @RequestParam의 required 속성을 false로 설정함
- Result 클래스로 컬렉션을 감싸서 향후 필요한 필드를 추가할 수 있게 함 (확장성 증가)