### PR TITLE
docs: #26 - .gitignore에 keystore.p12 추가 (HTTPS, SSL 인증서)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 application-profile.yml
+src/main/resources/keystore.p12
 
 # User-specific stuff
 .idea/**/workspace.xml


### PR DESCRIPTION
- HTTPS 설정을 위해 발급받은 SSL 인증서가 Git에 등록되지 않게 하기 위해 .gitignore에 keystore.p12를 추가함