### PR TITLE
refactor: #21 - [GET] 테마 전체 목록 조회 API 변경 (소수점 반올림, 이미지 url S3에서 받아오도록 Page 객체 변경)

### DIFF
--- a/src/main/java/com/maemae/escaperoom/dto/ThemeListDTO.java
+++ b/src/main/java/com/maemae/escaperoom/dto/ThemeListDTO.java
@@ -32,4 +32,8 @@ public class ThemeListDTO {
         this.location = location;
         this.ratingAvg = ratingAvg;
     }
+
+    public void changeImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/maemae/escaperoom/repository/ThemeRepositoryCustomImpl.java
+++ b/src/main/java/com/maemae/escaperoom/repository/ThemeRepositoryCustomImpl.java
@@ -5,6 +5,8 @@ import com.maemae.escaperoom.dto.ThemeListDTO;
 import com.maemae.escaperoom.entity.QCafe;
 import com.maemae.escaperoom.entity.QReview;
 import com.maemae.escaperoom.entity.QTheme;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
@@ -38,7 +40,7 @@ public class ThemeRepositoryCustomImpl implements ThemeRepositoryCustom {
                         theme.imageUrl,
                         cafe.name,
                         cafe.location,
-                        review.rating.avg().coalesce(-1.0)
+                        Expressions.template(Double.class, "ROUND({0}, 2)", review.rating.avg().coalesce(-1.0))
                 ))
                 .from(theme)
                 .leftJoin(theme.cafe, cafe)

--- a/src/main/java/com/maemae/escaperoom/service/ThemeService.java
+++ b/src/main/java/com/maemae/escaperoom/service/ThemeService.java
@@ -4,16 +4,30 @@ import com.maemae.escaperoom.dto.ThemeListDTO;
 import com.maemae.escaperoom.repository.ThemeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ThemeService {
 
     private final ThemeRepository themeRepository;
+    private final S3UploadService s3UploadService;
 
     public Page<ThemeListDTO> themeAllList(Pageable pageable) {
-        return themeRepository.themeAllListPage(pageable);
+
+        Page<ThemeListDTO> page = themeRepository.themeAllListPage(pageable);
+
+        List<ThemeListDTO> content = page.getContent();
+
+        for (ThemeListDTO dto : content) {
+            String S3imgUrl = s3UploadService.getThumbnailPath("theme_img/"+dto.getImageUrl());
+            dto.changeImageUrl(S3imgUrl);
+        }
+
+        return new PageImpl<>(content, pageable, page.getTotalElements());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
     web:
       pageable:
         default-page-size: 12
-        max-page-size: 200
+        max-page-size: 30
         one-indexed-parameters: true
 
   # Swagger 설정


### PR DESCRIPTION
[refactor:](https://github.com/maemae22/escape-room/commit/5648c699f5334bc323334f0f9199b3976d1a32c2) https://github.com/maemae22/escape-room/issues/21 [- 리뷰 평점 반올림하여 소수점 둘째 자리로 출력되도록 변경](https://github.com/maemae22/escape-room/commit/5648c699f5334bc323334f0f9199b3976d1a32c2) 

- Expressions.template() 메서드를 사용하여 ROUND(@@, 2) 함수를 적용함
- 정리 : https://maemae22.tistory.com/114


[feat:](https://github.com/maemae22/escape-room/commit/05557b30e613658f0863e49480fb4dc3cf3481f2) https://github.com/maemae22/escape-room/issues/21 [- ThemeListDTO에 imageUrl을 바꾸는 메서드 추가 (setter)](https://github.com/maemae22/escape-room/commit/05557b30e613658f0863e49480fb4dc3cf3481f2) 

- changeImageUrl 메서드를 통해 imageUrl을 바꿀 수 있음 (setter와 동일)


[feat:](https://github.com/maemae22/escape-room/commit/78c151592332c51f6524e1ed2fddb1932894aeb2) https://github.com/maemae22/escape-room/issues/21 [- 이미지 이름으로 S3에서 img url을 찾아 반환하도록 변경](https://github.com/maemae22/escape-room/commit/78c151592332c51f6524e1ed2fddb1932894aeb2) 

- 현재 DB에는 이미지 url이 아닌 이미지 이름으로 저장되어 있음
- Repository에서 받은 Page<ThemeListDTO>에서 .getContent() 으로 List<ThemeListDTO>을 꺼내 imageUrl을 S3에서 받아온 image url로 변경 후, 변경된 내용으로 새로운 Page 객체를 생성해 반환함


[conf:](https://github.com/maemae22/escape-room/commit/0f4278c6c2b814068783a642020e49e007eebb78) https://github.com/maemae22/escape-room/issues/21 [- pageable의 max-page-size 속성을 200 -> 30으로 변경](https://github.com/maemae22/escape-room/commit/0f4278c6c2b814068783a642020e49e007eebb78) 

- max-page-size(요청할 수 있는 최대 페이지 사이즈)를 200에서 30으로 변경함