### PR TITLE
feat: #38 - [GET] 테마 상세페이지 조회 API 개발 (/theme-detail/{themeId})

### DIFF
--- a/src/main/java/com/maemae/escaperoom/controller/ThemeController.java
+++ b/src/main/java/com/maemae/escaperoom/controller/ThemeController.java
@@ -1,5 +1,6 @@
 package com.maemae.escaperoom.controller;
 
+import com.maemae.escaperoom.dto.ThemeDetailDTO;
 import com.maemae.escaperoom.dto.ThemeListDTO;
 import com.maemae.escaperoom.service.ThemeService;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,6 +22,12 @@ public class ThemeController {
     public Result themeAllList(Pageable pageable) {
         Page<ThemeListDTO> themeList = themeService.themeAllList(pageable);
         return new Result(themeList);
+    }
+
+    @GetMapping("/theme-detail/{themeId}")
+    public Result themeDetail(@PathVariable Long themeId) {
+        ThemeDetailDTO themeDetailDTO = themeService.themeDetail(themeId);
+        return new Result(themeDetailDTO);
     }
 
     @Data

--- a/src/main/java/com/maemae/escaperoom/dto/ThemeDetailDTO.java
+++ b/src/main/java/com/maemae/escaperoom/dto/ThemeDetailDTO.java
@@ -1,0 +1,51 @@
+package com.maemae.escaperoom.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class ThemeDetailDTO {
+
+    private Long themeId;
+    private String name;
+    private String genre;
+    private String activity;
+    private Integer difficult;
+    private Integer limitTime;
+    private Integer recommendStart;
+    private Integer recommendEnd;
+    private String info;
+    private String imageUrl;
+
+    private Long cafeId;
+    private String cafeName;
+    private String domain;
+    private String location;
+
+    private Double ratingAvg;
+
+    @QueryProjection
+    public ThemeDetailDTO(Long themeId, String name, String genre, String activity, Integer difficult,
+                          Integer limitTime, Integer recommendStart, Integer recommendEnd, String info, String imageUrl,
+                          Long cafeId, String cafeName, String domain, String location, Double ratingAvg) {
+        this.themeId = themeId;
+        this.name = name;
+        this.genre = genre;
+        this.activity = activity;
+        this.difficult = difficult;
+        this.limitTime = limitTime;
+        this.recommendStart = recommendStart;
+        this.recommendEnd = recommendEnd;
+        this.info = info;
+        this.imageUrl = imageUrl;
+        this.cafeId = cafeId;
+        this.cafeName = cafeName;
+        this.domain = domain;
+        this.location = location;
+        this.ratingAvg = ratingAvg;
+    }
+
+    public void changeImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/maemae/escaperoom/repository/ThemeRepositoryCustom.java
+++ b/src/main/java/com/maemae/escaperoom/repository/ThemeRepositoryCustom.java
@@ -1,9 +1,11 @@
 package com.maemae.escaperoom.repository;
 
+import com.maemae.escaperoom.dto.ThemeDetailDTO;
 import com.maemae.escaperoom.dto.ThemeListDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ThemeRepositoryCustom {
     Page<ThemeListDTO> themeAllListPage(Pageable pageable);
+    ThemeDetailDTO themeDetail(Long themeId);
 }

--- a/src/main/java/com/maemae/escaperoom/repository/ThemeRepositoryCustomImpl.java
+++ b/src/main/java/com/maemae/escaperoom/repository/ThemeRepositoryCustomImpl.java
@@ -1,6 +1,8 @@
 package com.maemae.escaperoom.repository;
 
+import com.maemae.escaperoom.dto.QThemeDetailDTO;
 import com.maemae.escaperoom.dto.QThemeListDTO;
+import com.maemae.escaperoom.dto.ThemeDetailDTO;
 import com.maemae.escaperoom.dto.ThemeListDTO;
 import com.maemae.escaperoom.entity.QCafe;
 import com.maemae.escaperoom.entity.QReview;
@@ -56,5 +58,33 @@ public class ThemeRepositoryCustomImpl implements ThemeRepositoryCustom {
                 .from(theme);
 
         return PageableExecutionUtils.getPage(themeListContent, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public ThemeDetailDTO themeDetail(Long themeId) {
+
+        return queryFactory
+                .select(new QThemeDetailDTO(
+                        theme.id,
+                        theme.name,
+                        theme.genre,
+                        theme.activity,
+                        theme.difficult,
+                        theme.limitTime,
+                        theme.recommendStart,
+                        theme.recommendEnd,
+                        theme.info,
+                        theme.imageUrl,
+                        cafe.id,
+                        cafe.name,
+                        cafe.domain,
+                        cafe.location,
+                        Expressions.template(Double.class, "ROUND({0}, 2)", review.rating.avg().coalesce(-1.0))
+                ))
+                .from(theme)
+                .leftJoin(theme.cafe, cafe)
+                .leftJoin(theme.reviews, review)
+                .where(theme.id.eq(themeId))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/maemae/escaperoom/service/ThemeService.java
+++ b/src/main/java/com/maemae/escaperoom/service/ThemeService.java
@@ -1,5 +1,6 @@
 package com.maemae.escaperoom.service;
 
+import com.maemae.escaperoom.dto.ThemeDetailDTO;
 import com.maemae.escaperoom.dto.ThemeListDTO;
 import com.maemae.escaperoom.repository.ThemeRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,15 @@ public class ThemeService {
         }
 
         return new PageImpl<>(content, pageable, page.getTotalElements());
+    }
+
+    public ThemeDetailDTO themeDetail(Long themeId) {
+
+        ThemeDetailDTO themeDetailDTO = themeRepository.themeDetail(themeId);
+
+        String S3imgUrl = s3UploadService.getThumbnailPath("theme_img/"+themeDetailDTO.getImageUrl());
+        themeDetailDTO.changeImageUrl(S3imgUrl);
+
+        return themeDetailDTO;
     }
 }


### PR DESCRIPTION
[feat:](https://github.com/maemae22/escape-room/commit/0ce38e3916df87bc75a9d9adaab57b4f14c8bcb9) https://github.com/maemae22/escape-room/issues/38 [- 테마 상세정보 조회를 위한 ThemeDetailDTO 개발](https://github.com/maemae22/escape-room/commit/0ce38e3916df87bc75a9d9adaab57b4f14c8bcb9) 

- 테마 상세페이지에서 사용하기 위하여, 테마의 상세정보에 필요한 필드로 DTO를 작성함


[feat:](https://github.com/maemae22/escape-room/commit/3ecbbeb1926e4e706b2a5eeed2e869a37949c8d5) https://github.com/maemae22/escape-room/issues/38 [- 테마 상세정보 반환하는 쿼리 작성 (Repository)](https://github.com/maemae22/escape-room/commit/3ecbbeb1926e4e706b2a5eeed2e869a37949c8d5) 

- ThemeDetailDTO로 반환함
- 리뷰 평점은 반올림하여 소수점 둘째자리까지만 출력
- 파라미터로 받은 themeId에 해당하는 테마의 상세정보를 반환함



[feat:](https://github.com/maemae22/escape-room/commit/30b9af61b5324f60fa92dc864b6406ce98fae2a5) https://github.com/maemae22/escape-room/issues/38 [- 테마 상세페이지 조회 API 개발 (Service, Controller)](https://github.com/maemae22/escape-room/commit/30b9af61b5324f60fa92dc864b6406ce98fae2a5) 

- /theme-detail/{themeId} API 개발
- Service단에서 ThemeDetailDTO의 imageUrl을 S3에서 받아온 이미지 주소로 바꾸어서 반환함
- Controller : Result 클래스로 컬렉션을 감싸서 향후 필요한 필드를 추가할 수 있게 함 (확장성 증가)