### PR TITLE
feat: #43 - [GET] 이 업체의 다른 테마 리스트 2개 조회 API 개발 (/theme/others)

### DIFF
--- a/src/main/java/com/maemae/escaperoom/controller/ThemeController.java
+++ b/src/main/java/com/maemae/escaperoom/controller/ThemeController.java
@@ -40,6 +40,12 @@ public class ThemeController {
         return new Result(themeListByCafeId);
     }
 
+    @GetMapping("/theme/others")
+    public Result sameCafeOtherTwoThemeList(@RequestParam(value = "id") Long themeId) {
+        List<ThemeSimpleListDTO> twoThemeList = themeService.sameCafeOtherTwoThemeList(themeId);
+        return new Result(twoThemeList);
+    }
+
     @Data
     @AllArgsConstructor
     static class Result<T> {

--- a/src/main/java/com/maemae/escaperoom/repository/ThemeRepositoryCustom.java
+++ b/src/main/java/com/maemae/escaperoom/repository/ThemeRepositoryCustom.java
@@ -12,4 +12,5 @@ public interface ThemeRepositoryCustom {
     Page<ThemeListDTO> themeAllListPage(Pageable pageable);
     ThemeDetailDTO themeDetail(Long themeId);
     List<ThemeSimpleListDTO> themeListByCafeId(Long cafeId);
+    List<ThemeSimpleListDTO> sameCafeOtherThemeList(Long themeId);
 }

--- a/src/main/java/com/maemae/escaperoom/service/ThemeService.java
+++ b/src/main/java/com/maemae/escaperoom/service/ThemeService.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -52,5 +53,28 @@ public class ThemeService {
         }
 
         return themeList;
+    }
+
+    public List<ThemeSimpleListDTO> sameCafeOtherTwoThemeList(Long themeId) {
+
+        try {
+            List<ThemeSimpleListDTO> themeList = themeRepository.sameCafeOtherThemeList(themeId);
+            Collections.shuffle(themeList); // 리스트를 무작위로 섞음
+
+            for (ThemeSimpleListDTO dto : themeList) {
+                String S3imgUrl = s3UploadService.getThumbnailPath("theme_img/"+dto.getImageUrl());
+                dto.changeImageUrl(S3imgUrl);
+            }
+
+            if (themeList.size()<2) {
+                return themeList;
+            } else {
+                List<ThemeSimpleListDTO> randomTwoThemes = themeList.subList(0, 2);
+                return randomTwoThemes;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 }


### PR DESCRIPTION
[feat:](https://github.com/maemae22/escape-room/commit/3fe00063ae3394a9cbed9b1ed8c6a73cc5ff23c3) https://github.com/maemae22/escape-room/issues/43 [- 업체의 다른 테마 list 반환하는 쿼리 작성 (Repository)](https://github.com/maemae22/escape-room/commit/3fe00063ae3394a9cbed9b1ed8c6a73cc5ff23c3) 

- 서브 쿼리 사용
- 파라미터로 받은 themeId를 보유한 방탈출 카페(업체)의 다른 테마 list를 반환함
- where절 조건 : 파라미터로 받은 themeId와 같은 cafe id를 가져야함(eq) + 파라미터로 받은 themeId에 해당하는 테마는 제외함(ne)


[feat:](https://github.com/maemae22/escape-room/commit/d892f9176986951febebe9bacf42a947a298b0f6) https://github.com/maemae22/escape-room/issues/43 [- 이 업체의 다른 테마 리스트 2개 조회 API 개발 (Service, Controller)](https://github.com/maemae22/escape-room/commit/d892f9176986951febebe9bacf42a947a298b0f6) 

- [GET] /theme/others API 개발
- 파라미터로 받은 themeId에 해당하는 테마를 보유한 업체의 다른 테마 리스트 2개를 무작위로 `랜덤`으로 가져옴
- 이 업체의 다른 테마가 2개 미만일 경우, 있는 것만(2개 미만으로) 반환함
- Service단에서 ThemeSimpleListDTO의 imageUrl을 S3에서 받아온 이미지 주소로 바꾸어서 반환함