### PR TITLE
refactor: #51 - Review 부분 코드 리팩토링

### DIFF
--- a/src/main/java/com/maemae/escaperoom/controller/ReviewController.java
+++ b/src/main/java/com/maemae/escaperoom/controller/ReviewController.java
@@ -38,11 +38,7 @@ public class ReviewController {
     @DeleteMapping("/review/{reviewId}")
     public ResponseEntity<String> reviewDelete(@PathVariable Long reviewId) {
         String deleteReviewResult = reviewService.reviewDelete(reviewId);
-        if (deleteReviewResult.equals("success")) {
-            return new ResponseEntity(deleteReviewResult, HttpStatus.OK);
-        } else {
-            return new ResponseEntity(deleteReviewResult, HttpStatus.BAD_REQUEST);
-        }
+        return responseEntityByResultMessage(deleteReviewResult);
     }
 
     @GetMapping("/review-list")
@@ -56,20 +52,16 @@ public class ReviewController {
     public ResponseEntity<String> reviewUpdate(@PathVariable Long reviewId,
                                                @RequestBody ReviewUpdateDTO reviewUpdateDTO) {
         String updateReviewResult = reviewService.reviewUpdate(reviewId, reviewUpdateDTO);
-        if (updateReviewResult.equals("success")) {
-            return new ResponseEntity(updateReviewResult, HttpStatus.OK);
-        } else {
-            return new ResponseEntity(updateReviewResult, HttpStatus.BAD_REQUEST);
-        }
+        return responseEntityByResultMessage(updateReviewResult);
     }
 
     @PostMapping("/review/check")
     public ResponseEntity<String> reviewPasswordCheck(@RequestBody ReviewPasswordCheckDTO reviewPasswordCheckDTO) {
         String checkResult = reviewService.reviewPasswordCheck(reviewPasswordCheckDTO);
-        return returnResponseEntityByResultMessage(checkResult);
+        return responseEntityByResultMessage(checkResult);
     }
 
-    public ResponseEntity<String> returnResponseEntityByResultMessage(String resultMessage) {
+    public ResponseEntity<String> responseEntityByResultMessage(String resultMessage) {
         if (resultMessage.equals("success")) {
             return new ResponseEntity(resultMessage, HttpStatus.OK);
         } else {

--- a/src/main/java/com/maemae/escaperoom/controller/ReviewController.java
+++ b/src/main/java/com/maemae/escaperoom/controller/ReviewController.java
@@ -25,8 +25,9 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping("/review/insert")
-    public HashMap<String, String> reviewInsert(@RequestBody ReviewDTO reviewDTO) {
-        return reviewService.reviewInsert(reviewDTO);
+    public ResponseEntity<String> reviewInsert(@RequestBody ReviewDTO reviewDTO) {
+        String insertReviewResult = reviewService.reviewInsert(reviewDTO);
+        return responseEntityByResultMessage(insertReviewResult);
     }
 
     @GetMapping("/review")

--- a/src/main/java/com/maemae/escaperoom/controller/ReviewController.java
+++ b/src/main/java/com/maemae/escaperoom/controller/ReviewController.java
@@ -25,7 +25,7 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping("/review/insert")
-    public HashMap<String, String> reviewInsert(ReviewDTO reviewDTO) {
+    public HashMap<String, String> reviewInsert(@RequestBody ReviewDTO reviewDTO) {
         return reviewService.reviewInsert(reviewDTO);
     }
 
@@ -53,7 +53,8 @@ public class ReviewController {
     }
 
     @PutMapping("/review/{reviewId}")
-    public ResponseEntity<String> reviewUpdate(@PathVariable Long reviewId, ReviewUpdateDTO reviewUpdateDTO) {
+    public ResponseEntity<String> reviewUpdate(@PathVariable Long reviewId,
+                                               @RequestBody ReviewUpdateDTO reviewUpdateDTO) {
         String updateReviewResult = reviewService.reviewUpdate(reviewId, reviewUpdateDTO);
         if (updateReviewResult.equals("success")) {
             return new ResponseEntity(updateReviewResult, HttpStatus.OK);

--- a/src/main/java/com/maemae/escaperoom/repository/ReviewRepository.java
+++ b/src/main/java/com/maemae/escaperoom/repository/ReviewRepository.java
@@ -4,6 +4,7 @@ import com.maemae.escaperoom.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,4 +19,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("select r.password from Review r where r.id= :reviewId")
     String findReviewPasswordById(@Param("reviewId") Long reviewId);
+
+    @Modifying
+    @Query("delete from Review r where r.id= :reviewId")
+    void deleteReviewByReviewId(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/com/maemae/escaperoom/service/ReviewService.java
+++ b/src/main/java/com/maemae/escaperoom/service/ReviewService.java
@@ -40,9 +40,10 @@ public class ReviewService {
         return null;
     }
 
+    @Transactional
     public String reviewDelete(Long reviewId) {
         try {
-            reviewRepository.deleteById(reviewId);
+            reviewRepository.deleteReviewByReviewId(reviewId);
         } catch (Exception e) {
             e.printStackTrace();
             return "failed";

--- a/src/main/java/com/maemae/escaperoom/service/ReviewService.java
+++ b/src/main/java/com/maemae/escaperoom/service/ReviewService.java
@@ -20,18 +20,14 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
 
-    public HashMap<String, String> reviewInsert(ReviewDTO reviewDTO) {
-        HashMap<String, String> result = new HashMap<>();
-
+    public String reviewInsert(ReviewDTO reviewDTO) {
         try {
             reviewRepository.save(reviewDTO.toEntity());
         } catch (Exception e) {
             e.printStackTrace();
-            result.put("resultCode", "failed");
-            return result;
+            return "failed";
         }
-        result.put("resultCode", "success");
-        return result;
+        return "success";
     }
 
     public ReviewOneDTO reviewOneByReviewId(Long reviewId) {


### PR DESCRIPTION
[refactor:](https://github.com/maemae22/escape-room/commit/6641013471344fbb59f3268b4a3c8211e497e9e9) https://github.com/maemae22/escape-room/issues/51 [-](https://github.com/maemae22/escape-room/commit/6641013471344fbb59f3268b4a3c8211e497e9e9) @requestbody [추가](https://github.com/maemae22/escape-room/commit/6641013471344fbb59f3268b4a3c8211e497e9e9) 

- 클라이언트가 전송한 JSON, XML 또는 기타 형식의 데이터를 자바 객체로 변환하기 위하여 @requestbody 어노테이션 추가
- HTTP 요청의 본문(body)에 있는 데이터를 컨트롤러의 메서드 파라미터로 매핑하는 데 사용된다


[refactor:](https://github.com/maemae22/escape-room/commit/742b89a4adc836d7c7ccac9ee62371e493478daf) https://github.com/maemae22/escape-room/issues/51 [- 중복 코드 메서드로 추출하여 제거](https://github.com/maemae22/escape-room/commit/742b89a4adc836d7c7ccac9ee62371e493478daf) 

- 중복되는 코드가 있어, 공통 부분을 메서드로 만들어 사용함

[refactor:](https://github.com/maemae22/escape-room/commit/a85d2d7375050b39e0e35c14240fab4b1756b360) https://github.com/maemae22/escape-room/issues/51 [- 응답 결과를 ResponseEntity로 반환하도록 수정](https://github.com/maemae22/escape-room/commit/a85d2d7375050b39e0e35c14240fab4b1756b360) 

- 기존 HashMap으로 응답값을 보냈었는데, 다양한 상태 코드, 응답 본문, 헤더 등을 설정할 수 있다는 장점을 가진 ResponseEntity로 반환형을 변경함



[refactor:](https://github.com/maemae22/escape-room/commit/781f1e5b04912087c6f8da693ad8df53c3b0b540) https://github.com/maemae22/escape-room/issues/51 [- 리뷰 삭제 쿼리 JPQL로 변경](https://github.com/maemae22/escape-room/commit/781f1e5b04912087c6f8da693ad8df53c3b0b540) 

- 별도의 작업을 할 필요없이 삭제하는 경우이기 때문에 @query를 사용함
- 기존 방법대로 삭제할 경우, select를 통해 Entity를 찾아오고 그 Entity를 삭제하는 delete 쿼리가 나간다. 즉, select, delete 각각 1번씩 총 2번 쿼리가 나가게 된다.
- 삭제하려는 인스턴스가 영속성 컨텍스트에 없는 상황일 경우 이렇게 2번 쿼리가 나가게 되므로 이런 경우에는 @query를 사용하여 JPQL을 통해 delete 쿼리 1번으로 바로 삭제하는 것이 더 효율성이 좋음